### PR TITLE
Using contains to validate that an element contains a specific text

### DIFF
--- a/cypress/integration/webdriver-uni/contact-us.spec.js
+++ b/cypress/integration/webdriver-uni/contact-us.spec.js
@@ -16,7 +16,7 @@ describe('Test Contact Us form via Webdriveruni', () => {
        cy.get('[name="last_name"]').type('Diaz')
        cy.get('textarea.feedback-input').type('text test')
        cy.get('[type="submit"]').click()
-       cy.get('body').should('contain', 'Error: all fields are required')
-       cy.get('body').should('contain', 'Error: Invalid email address')
+       cy.get('body').contains('Error: all fields are required')
+       cy.get('body').contains('Error: Invalid email address')
     });
 });


### PR DESCRIPTION
# How to use contains to validate text in elements

E.g. `cy.get('body').contains('Error: Invalid email address')`