### PR TITLE
Using cy.title to validate the title of a page

### DIFF
--- a/cypress/integration/webdriver-uni/contact-us.spec.js
+++ b/cypress/integration/webdriver-uni/contact-us.spec.js
@@ -3,6 +3,7 @@ describe('Test Contact Us form via Webdriveruni', () => {
     it.only('Should be able to submit a successful submission via contact us form', () => {
        cy.visit('http://webdriveruniversity.com/Contact-Us/contactus.html')
        cy.document().should('have.property', 'charset').and('eq', 'UTF-8')
+       cy.title().should('include', 'WebDriver | Contact Us')
        cy.get('[name="first_name"]').type('Dario')
        cy.get('[name="last_name"]').type('Diaz')
        cy.get('[name="email"]').type('dario@test.com')


### PR DESCRIPTION
## We learned how to validate the title of a page using:

`cy.title().should('include', 'WebDriver | Contact Us')`