### PR TITLE
Mores examples of chaining - now using index

### DIFF
--- a/cypress/integration/automation-test-store/inspect-item.js
+++ b/cypress/integration/automation-test-store/inspect-item.js
@@ -8,4 +8,8 @@ describe('Inspect Automation Test Store items using chain of commands', () => {
         cy.visit('https://automationteststore.com')
         cy.get('.prdocutname').contains('Skinsheen Bronzer Stick').click()
     })
+    it('Should be able to click on the first item using index', () => {
+        cy.visit('https://automationteststore.com')
+        cy.get('.fixed_wrapper').find('.prdocutname').eq(0).click()
+    })
 })


### PR DESCRIPTION
# More chaining examples - using index:

- Example code:
- `cy.get('.fixed_wrapper').find('.prdocutname').eq(0).click()`